### PR TITLE
removing an unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "prop-types": "^15.5.10",
     "query-string": "^4.3.2",
     "react": "^15.4.2",
-    "react-bootstrap": "^0.30.7",
     "react-flexbox-grid": "^1.1.3",
     "react-router-dom": "^4.0.0",
     "redux-form": "^6.1.1"


### PR DESCRIPTION
react-bootstrap isn't even in use in this repo any longer so we can prune it.